### PR TITLE
Making 3rd TS the sample of interest

### DIFF
--- a/include/TrigScint/TrigScintRecHitProducer.h
+++ b/include/TrigScint/TrigScintRecHitProducer.h
@@ -81,6 +81,9 @@ class TrigScintRecHitProducer : public framework::Producer {
 
   /// Total number of photoelectrons per MIP
   double pePerMip_{13.5};
+
+  /// Total number of photoelectrons per MIP
+  int sample_of_interest_{2};
 };
 
 }  // namespace trigscint

--- a/python/trigScint.py
+++ b/python/trigScint.py
@@ -118,7 +118,8 @@ class TrigScintRecHitProducer(ldmxcfg.Producer) :
         self.input_collection="trigScintQIEDigisUp"
         self.input_pass_name=""   #take any pass
         self.output_collection="trigScintRecHitsUp"
-        self.verbose = False        
+        self.verbose = False
+        self.sample_of_interest=2 # Sample of interest. Range 0 to 3
 
     def up() : 
         """Get the rechit producer for upstream pad"""

--- a/python/trigScint.py
+++ b/python/trigScint.py
@@ -71,7 +71,7 @@ class TrigScintQIEDigiProducer(ldmxcfg.Producer) :
         self.expo_k=0.1          # Inverse of decay time of piece-wise exponential 
         self.expo_tmax=5.0       # Time at which piece-wise exponential peaks
         self.maxts=5             # No. of time samples to analyze
-        self.toff_overall = 30.0 # Global time offset
+        self.toff_overall = 55.0 # Global time offset
         self.tdc_thr = 3.4       # Threshold current in uA for TDC latch
         self.pedestal= 6.0       # QIE pedestal value (in fC)
         self.elec_noise = 1.5    # Electronic noise (in fC)

--- a/src/TrigScint/TrigScintRecHitProducer.cxx
+++ b/src/TrigScint/TrigScintRecHitProducer.cxx
@@ -44,17 +44,17 @@ void TrigScintRecHitProducer::produce(framework::Event &event) {
     hit.setBarID(digi.getChanID());
     hit.setBeamEfrac(-1.);
 
-    hit.setAmplitude(qie.ADC2Q(adc[1]) +
-                     qie.ADC2Q(adc[2]));  // femptocoulombs
+    hit.setAmplitude(qie.ADC2Q(adc[2]) +
+                     qie.ADC2Q(adc[3]));  // femptocoulombs
 
-    if (tdc[1] > 49)
+    if (tdc[2] > 49)
       hit.setTime(-999.);
     else
-      hit.setTime(tdc[1] * 0.5);
+      hit.setTime(tdc[2] * 0.5);
 
-    hit.setEnergy((qie.ADC2Q(adc[1]) + qie.ADC2Q(adc[2]) - pedestal_) * 6250. /
+    hit.setEnergy((qie.ADC2Q(adc[2]) + qie.ADC2Q(adc[3]) - pedestal_) * 6250. /
                   gain_ * mevPerMip_ / pePerMip_);  // MeV
-    hit.setPE((qie.ADC2Q(adc[1]) + qie.ADC2Q(adc[2]) - pedestal_) * 6250. /
+    hit.setPE((qie.ADC2Q(adc[2]) + qie.ADC2Q(adc[3]) - pedestal_) * 6250. /
               gain_);
     trigScintHits.push_back(hit);
   }

--- a/src/TrigScint/TrigScintRecHitProducer.cxx
+++ b/src/TrigScint/TrigScintRecHitProducer.cxx
@@ -23,11 +23,20 @@ void TrigScintRecHitProducer::configure(
   inputPassName_ = parameters.getParameter<std::string>("input_pass_name");
   outputCollection_ = parameters.getParameter<std::string>("output_collection");
   verbose_ = parameters.getParameter<bool>("verbose");
+  sample_of_interest_ = parameters.getParameter<int>("sample_of_interest");
 }
 
 void TrigScintRecHitProducer::produce(framework::Event &event) {
   // initialize QIE object for linearizing ADCs
   SimQIE qie;
+
+  // Ensure the sample of interest <4
+  if(sample_of_interest_>3) {
+    ldmx_log(error)<<"sample_of_interest_ should be one of 0,1,2,3\n"
+		   <<"Currently, sample_of_interest = "<<sample_of_interest_
+		   <<"\n";
+    return;
+  }
 
   // looper over sim hits and aggregate energy depositions
   // for each detID
@@ -44,18 +53,20 @@ void TrigScintRecHitProducer::produce(framework::Event &event) {
     hit.setBarID(digi.getChanID());
     hit.setBeamEfrac(-1.);
 
-    hit.setAmplitude(qie.ADC2Q(adc[2]) +
-                     qie.ADC2Q(adc[3]));  // femptocoulombs
+    hit.setAmplitude(qie.ADC2Q(adc[sample_of_interest_]) +
+                     qie.ADC2Q(adc[sample_of_interest_+1]));  // femptocoulombs
 
-    if (tdc[2] > 49)
+    if (tdc[sample_of_interest_] > 49)
       hit.setTime(-999.);
     else
-      hit.setTime(tdc[2] * 0.5);
+      hit.setTime(tdc[sample_of_interest_] * 0.5);
 
-    hit.setEnergy((qie.ADC2Q(adc[2]) + qie.ADC2Q(adc[3]) - pedestal_) * 6250. /
-                  gain_ * mevPerMip_ / pePerMip_);  // MeV
-    hit.setPE((qie.ADC2Q(adc[2]) + qie.ADC2Q(adc[3]) - pedestal_) * 6250. /
-              gain_);
+    hit.setEnergy((qie.ADC2Q(adc[sample_of_interest_])+
+		   qie.ADC2Q(adc[sample_of_interest_+1])-pedestal_)
+		  *6250. / gain_ * mevPerMip_ / pePerMip_);  // MeV
+    hit.setPE((qie.ADC2Q(adc[sample_of_interest_])+
+	       qie.ADC2Q(adc[sample_of_interest_+1]) - pedestal_)
+	      *6250. / gain_);
     trigScintHits.push_back(hit);
   }
   // Create the container to hold the


### PR DESCRIPTION
Out of the 5 time samples that the QIE analyzes per event, we wish to consider the third time sample as the sample of interest. As a result, the `TrigScintRecHitProducer`  will reconstruct deposited energy from the ADCs received in the 3rd and 4th time sample.