### PR TITLE
Tweaks to make simulation reconstruction closer to data 

### DIFF
--- a/exampleConfigs/runTBHitana.py
+++ b/exampleConfigs/runTBHitana.py
@@ -19,7 +19,7 @@ from LDMX.TrigScint.trigScint import TestBeamHitAnalyzer
 # ------------------- all set; setup in detail, and run with these settings ---------------
 
 tsEv=TestBeamHitAnalyzer("plotMaker")
-tsEv.input_pass_name=inputPassName
+tsEv.inputPassName=inputPassName
 # now in default config, too, but with test beam values :
 #these are derived as the mean of gaussian fits to the "event pedestal" (average over middle two quartiles) for each channel
 tsEv.startSample=startSample

--- a/exampleConfigs/runTBintercalib.py
+++ b/exampleConfigs/runTBintercalib.py
@@ -1,0 +1,143 @@
+import sys
+from os.path import exists
+from LDMX.Framework import ldmxcfg
+
+
+thisPassName="interCalib"
+
+p = ldmxcfg.Process(thisPassName)
+
+startSample=14
+if len(sys.argv) > 1 :
+    inputFile=sys.argv[1]
+else :
+    print("got to specify an input file")
+    exit 
+if len(sys.argv) > 2 :
+    inputPassName=sys.argv[2]
+else :
+    inputPassName="conv" #"sim"
+
+    
+p.run = 10
+#p.maxEvents = 2000
+p.inputFiles = [ inputFile ]
+outname=inputFile.replace(".root", "_interCalib.root")
+p.outputFiles = [ outname ]
+print("Running over input file: "+p.inputFiles[0])
+print("Producing output file: "+p.outputFiles[0])
+
+from LDMX.TrigScint.trigScint import TrigScintRecHitProducer
+from LDMX.TrigScint.trigScint import TrigScintClusterProducer
+
+
+#assume we have run linearizer, so we can and have derived the gains
+nChannels=12
+
+gainList=[2e6]*nChannels
+pedList=[6.]*nChannels
+responseList=[1.]*nChannels
+
+#look them up and run analyzers and reco
+#now if there is a gain file, use that instead to read in the gain for each channel
+gainFileName=inputFile.replace(".root", "_gains.txt")
+gainFileName=gainFileName.replace("_TBreco", "")
+
+if exists(gainFileName) :
+    with open(gainFileName) as f:
+        for line in f.readlines() :#        line = f.readline()
+            line=line.split(',')  #values are comma separated, one channel per line: channelNB, gain
+            #        print(line[1:])
+            gainList[ int(line[0].strip()) ] = float(line[1].strip())
+            #for line in lines :
+
+print("Using this list of gains:")
+print(gainList)
+
+#now if there is a ped file, use that instead to read in the ped for each channel
+pedFileName=gainFileName.replace("gains", "peds")
+
+if exists(pedFileName) :
+    with open(pedFileName) as f:
+        for line in f.readlines() :#        line = f.readline()
+            line=line.split(',')  #values are comma separated, one channel per line: channelNB, ped
+            pedList[ int(line[0].strip()) ] = float(line[1].strip())
+
+print("Using this list of peds:")
+print(pedList)
+
+#now if there is a response file, use that instead to read in the response for each channel
+responseFileName=inputFile.replace(".root", "_response.txt")
+
+if exists(responseFileName) :
+    with open(responseFileName) as f:
+        for line in f.readlines() :#        line = f.readline()
+            line=line.split(',')  #values are comma separated, one channel per line: channelNB, response
+            responseList[ int(line[0].strip()) ] = float(line[1].strip())
+
+print("Using this list of relative response correction factors:")
+print(responseList)
+
+
+from LDMX.TrigScint.trigScint import QIEAnalyzer
+
+tsAna=QIEAnalyzer("QIEplotMaker")
+tsAna.inputPassName=inputPassName
+tsAna.startSample=0
+tsAna.pedestals=pedList
+tsAna.gain=gainList
+
+outname=outname.replace(".root", "_plots.root")
+p.histogramFile = outname 
+
+
+
+from LDMX.TrigScint.trigScint import TestBeamHitProducer
+
+tbHitsUp  =TestBeamHitProducer("tbHits")
+tbHitsUp.input_pass_name=inputPassName
+tbHitsUp.input_collection="QIEsamplesUp"
+tbHitsUp.pedestals=pedList
+tbHitsUp.gain=gainList 
+tbHitsUp.MIPresponse=responseList
+tbHitsUp.startSample=startSample
+tbHitsUp.pulseWidth=12 #5 
+tbHitsUp.pulseWidthLYSO=12 #14
+tbHitsUp.doCleanHits=True
+tbHitsUp.nInstrumentedChannels=12
+
+
+from LDMX.TrigScint.trigScint import TestBeamClusterProducer
+
+cleanClustersUp  =TestBeamClusterProducer("cleanClusters")
+cleanClustersUp.input_pass_name=thisPassName
+cleanClustersUp.input_collection=tbHitsUp.outputCollection
+cleanClustersUp.output_collection=cleanClustersUp.output_collection+"Clean"
+cleanClustersUp.pad_time=100.
+cleanClustersUp.time_tolerance=999.
+cleanClustersUp.verbosity=0
+cleanClustersUp.clustering_threshold = 40.  #to add in neighboring
+cleanClustersUp.seed_threshold = 50.
+cleanClustersUp.doCleanHits=True
+
+
+from LDMX.TrigScint.trigScint import QualityFlagAnalyzer
+
+flagAna=QualityFlagAnalyzer("plotMaker")
+flagAna.inputEventPassName=inputPassName
+flagAna.inputHitPassName=thisPassName
+flagAna.startSample=0
+flagAna.pedestals=pedList
+flagAna.gain=gainList
+
+
+p.sequence = [
+    tbHitsUp,
+    cleanClustersUp,
+    tsAna,
+    flagAna
+    ]
+
+
+
+p.termLogLevel = 2 #0

--- a/exampleConfigs/runTSsim.py
+++ b/exampleConfigs/runTSsim.py
@@ -1,0 +1,111 @@
+import sys
+from LDMX.Framework import ldmxcfg
+from LDMX.SimCore import generators
+from LDMX.SimCore import simulator
+
+
+thisPassName="sim"
+p = ldmxcfg.Process(thisPassName)
+
+gunZpos=1100 #3000  #mm -- define as positive here, for file naming; set sign below
+detV=2        #detector geometry version number 
+beamXsmear=7.5 #mm
+beamYsmear=20 #mm
+noisePerEvent=1.  #average number of PEs from SiPM noise per event (gets scaled by nTimeSamples to be constant)
+startSample=17.
+if len(sys.argv) > 1 :
+    nTimeSamples=int(sys.argv[1])
+else :
+    nTimeSamples=30 #config default is 5 
+if len(sys.argv) > 2 :
+    elecNoise=float(sys.argv[2])
+else :
+    elecNoise=1.5 #config default is 1.5
+if len(sys.argv) > 3 :
+    kExpo=float(sys.argv[3])
+else :
+    kExpo=0.1   #config default is 0.1
+    
+p.run = 10
+p.maxEvents = 2000
+p.outputFiles = ['testbeamSim_zNeg'+str(gunZpos)+'mm_beamSpot'+str(beamXsmear)+'x'+str(beamYsmear)+'mm_'+str(nTimeSamples)+'tSamp_eNoise'+str(elecNoise)+'_tauInv'+str(kExpo)+'_detV'+str(detV)+'_'+str(p.maxEvents)+'ev.root']
+print("Producing output file: "+p.outputFiles[0])
+
+gunZpos   =-float(gunZpos)  #get sign right, and make floats, to use as parameters
+beamXsmear=float(beamXsmear)
+beamYsmear=float(beamYsmear)
+
+gun = generators.gun('particle_gun')
+gun.particle = 'e-'
+gun.direction = [0., 0., 1.]
+gun.position = [0., 0., gunZpos]
+gun.energy = 4.   #gev
+
+simulation = simulator.simulator('test_TS')
+simulation.generators=[gun]
+simulation.setDetector('ldmx-hcal-prototype-v'+str(detV)+'.0')
+simulation.beamSpotSmear = [beamXsmear, beamYsmear, 0] #mm, at start position
+
+from LDMX.TrigScint.trigScint import TrigScintQIEDigiProducer
+from LDMX.TrigScint.trigScint import TrigScintRecHitProducer
+from LDMX.TrigScint.trigScint import TrigScintClusterProducer
+
+tsDigis = TrigScintQIEDigiProducer.up()
+tsDigis.number_of_strips = 12
+tsDigis.mean_noise=float(noisePerEvent/nTimeSamples)
+tsDigis.maxts = nTimeSamples
+tsDigis.elec_noise = elecNoise
+tsDigis.expo_k = kExpo
+tsDigis.sipm_gain = 2.e6
+tsDigis.zeroSupp_in_pe=0.5
+tsDigis.toff_overall = 25.*startSample
+tsDigis.pe_per_mip = 110. #from fit to 2-hit clusters in data run 183, April4 2310, all plastic
+
+tsRecHits = TrigScintRecHitProducer.up()
+tsRecHits.pe_per_mip = tsDigis.pe_per_mip #pick it up here too
+tsRecHits.gain = tsDigis.gain # same
+
+
+tsCl = TrigScintClusterProducer.up()
+tsCl.input_collection = tsRecHits.output_collection
+tsCl.pad_time = 100.
+tsCl.time_tolerance = 999.
+#tsCl.verbosity = 3
+tsCl.clustering_threshold = 30.  #to add in neighboring
+tsCl.seed_threshold = 40.
+
+
+
+from LDMX.TrigScint.trigScint import EventReadoutProducer
+
+tsEv=EventReadoutProducer("eventLinearizer")
+tsEv.input_pass_name=thisPassName
+tsEv.input_collection=tsDigis.output_collection
+tsEv.time_shift=0 #timeOffset
+
+nChannels=12
+gainList=[tsDigis.sipm_gain]*nChannels
+pedList=[tsDigis.pedestal]*nChannels
+
+
+from LDMX.TrigScint.trigScint import QIEAnalyzer
+
+tsAna=QIEAnalyzer("plotMaker")
+tsAna.inputPassName=thisPassName
+tsAna.startSample=0
+tsAna.pedestals=pedList
+tsAna.gain=gainList
+
+outname=p.outputFiles[0].replace(".root", "_plots.root")
+p.histogramFile = outname 
+
+p.sequence=[simulation,
+                  tsDigis,
+                  tsRecHits,
+                  tsCl,
+                  tsEv,
+                  tsAna
+                  ]
+
+
+p.termLogLevel = 2 #0

--- a/exampleConfigs/runTSsimTBreco.py
+++ b/exampleConfigs/runTSsimTBreco.py
@@ -1,0 +1,137 @@
+import sys
+from os.path import exists
+from LDMX.Framework import ldmxcfg
+
+
+thisPassName="TBreco"
+
+p = ldmxcfg.Process(thisPassName)
+
+startSample=14
+if len(sys.argv) > 1 :
+    inputFile=sys.argv[1]
+else :
+    print("got to specify an input file")
+    exit 
+if len(sys.argv) > 2 :
+    inputPassName=sys.argv[2]
+else :
+    inputPassName="conv" #"sim"
+
+    
+p.run = 10
+#p.maxEvents = 2000
+p.inputFiles = [ inputFile ]
+outname=inputFile.replace(".root", "_TBreco.root")
+p.outputFiles = [ outname ]
+print("Running over input file: "+p.inputFiles[0])
+print("Producing output file: "+p.outputFiles[0])
+
+from LDMX.TrigScint.trigScint import TrigScintRecHitProducer
+from LDMX.TrigScint.trigScint import TrigScintClusterProducer
+
+
+#assume we have run linearizer, so we can and have derived the gains
+nChannels=12
+
+gainList=[2e6]*nChannels
+pedList=[6.]*nChannels
+
+#look them up and run analyzers and reco
+#now if there is a gain file, use that instead to read in the gain for each channel
+gainFileName=inputFile.replace(".root", "_gains.txt")
+
+if exists(gainFileName) :
+    with open(gainFileName) as f:
+        for line in f.readlines() :
+            line=line.split(',')  #values are comma separated, one channel per line: channelNB, gain
+            gainList[ int(line[0].strip()) ] = float(line[1].strip())
+
+print("Using this list of gains:")
+print(gainList)
+
+#now if there is a ped file, use that instead to read in the ped for each channel
+pedFileName=inputFile.replace(".root", "_peds.txt")
+
+if exists(pedFileName) :
+    with open(pedFileName) as f:
+        for line in f.readlines() :
+            line=line.split(',')  #values are comma separated, one channel per line: channelNB, ped
+            pedList[ int(line[0].strip()) ] = float(line[1].strip())
+
+print("Using this list of peds:")
+print(pedList)
+
+
+
+from LDMX.TrigScint.trigScint import QIEAnalyzer
+
+tsAna=QIEAnalyzer("QIEplotMaker")
+tsAna.inputPassName=inputPassName
+tsAna.startSample=0
+tsAna.pedestals=pedList
+tsAna.gain=gainList
+
+outname=outname.replace(".root", "_plots.root")
+p.histogramFile = outname 
+
+
+
+from LDMX.TrigScint.trigScint import TestBeamHitProducer
+
+tbHitsUp  =TestBeamHitProducer("tbHits")
+tbHitsUp.input_pass_name=inputPassName
+tbHitsUp.input_collection="QIEsamplesUp"
+tbHitsUp.pedestals=pedList
+tbHitsUp.gain=gainList 
+tbHitsUp.startSample=startSample
+tbHitsUp.pulseWidth=12 #5 
+tbHitsUp.pulseWidthLYSO=14
+tbHitsUp.doCleanHits=True
+tbHitsUp.nInstrumentedChannels=12
+
+
+from LDMX.TrigScint.trigScint import TestBeamClusterProducer
+
+tbClustersUp  =TestBeamClusterProducer("tbClusters")
+tbClustersUp.input_pass_name=thisPassName
+tbClustersUp.input_collection=tbHitsUp.outputCollection
+tbClustersUp.pad_time=100.
+tbClustersUp.time_tolerance=999.
+tbClustersUp.verbosity=0
+tbClustersUp.clustering_threshold = 40.  #to add in neighboring
+tbClustersUp.seed_threshold = 50.   # i think 50 cuts off the low tail of the PE distribution 
+
+
+cleanClustersUp  =TestBeamClusterProducer("cleanClusters")
+cleanClustersUp.input_pass_name=thisPassName
+cleanClustersUp.input_collection=tbHitsUp.outputCollection
+cleanClustersUp.output_collection=tbClustersUp.output_collection+"Clean"
+cleanClustersUp.pad_time=100.
+cleanClustersUp.time_tolerance=999.
+cleanClustersUp.verbosity=0
+cleanClustersUp.clustering_threshold = 40.  #to add in neighboring
+cleanClustersUp.seed_threshold = 50.
+cleanClustersUp.doCleanHits=True
+
+
+from LDMX.TrigScint.trigScint import QualityFlagAnalyzer
+
+flagAna=QualityFlagAnalyzer("plotMaker")
+flagAna.inputEventPassName=inputPassName
+flagAna.inputHitPassName=thisPassName
+flagAna.startSample=0
+flagAna.pedestals=pedList
+flagAna.gain=gainList
+
+p.sequence = [
+    tbHitsUp,
+    tbClustersUp,
+    cleanClustersUp,
+#    tsAna,
+    flagAna
+    ]
+
+
+
+p.termLogLevel = 2 #0

--- a/include/TrigScint/QualityFlagAnalyzer.h
+++ b/include/TrigScint/QualityFlagAnalyzer.h
@@ -1,0 +1,78 @@
+/**
+ * @file QualityFlagAnalyzer.h
+ * @brief
+ * @author
+ */
+
+#ifndef TRIGSCINT_QUALITYFLAGANALYZER_H
+#define TRIGSCINT_QUALITYFLAGANALYZER_H
+
+//LDMX Framework                               
+#include "Framework/Configure/Parameters.h"
+#include "Framework/EventProcessor.h" //Needed to declare processor
+#include "TrigScint/Event/EventReadout.h"
+#include "TrigScint/Event/TestBeamHit.h"
+#include "TH1.h"
+#include "TH2.h"
+
+namespace trigscint {
+
+  /**
+   * @class QualityFlagAnalyzer
+   * @brief
+   */
+  class QualityFlagAnalyzer : public framework::Analyzer {
+  public:
+
+	QualityFlagAnalyzer(const std::string& name, framework::Process& process); // : framework::Analyzer(name, process) {}
+	virtual ~QualityFlagAnalyzer();
+    virtual void configure(framework::config::Parameters &parameters);
+
+    virtual void analyze( const framework::Event &event) final override;
+
+	//
+	virtual void onFileOpen();
+
+	//
+	virtual void onFileClose();
+
+    virtual void onProcessStart() final override;
+
+    virtual void onProcessEnd() final override;
+
+	
+  private:
+
+	std::vector <std::vector <TH1F*> > vChargeVsTime;
+	
+
+	//configurable parameters
+    std::string inputEventCol_;   //full event stream input 
+    std::string inputEventPassName_{""};
+    std::string inputHitCol_;     // hit collection
+    std::string inputHitPassName_{""};
+	std::vector<double> peds_;
+	std::vector<double> gain_;
+	int startSample_{0};
+
+	//plotting stuff 
+	int evNb;
+    const int nEv{200};
+    const int nChannels{16};
+    const int nFlags{6};
+	int peFillNb{0};
+	
+	//make sure to match constants above 
+	const int flags[6] = {16,8,4,2,1,0};  //this order just makes looping easier
+    int nEvDrawn[6]={0}; //keep a counter for each flag type to get good stats
+	TH1F* hOut[200][16];
+	TH1F* hOutPE[200][16];
+	TH1F* hOutFlag[6][200][16]; //for 4 quality flags and 0 (no flag)
+	TH1F* hPE[16];
+	
+	TH2F* hTDCfireChanvsEvent;
+
+  };
+}
+
+#endif /* TRIGSCINT_QUALITYFLAGANALYZER_H */

--- a/include/TrigScint/SimQIE.h
+++ b/include/TrigScint/SimQIE.h
@@ -106,7 +106,7 @@ class SimQIE {
    * @param pulse pointer to the pulse we want to analyze
    * @note ideally, checks if the amplitude is above some threshold.
    */
-  bool PulseCut(QIEInputPulse* pulse);
+  bool PulseCut(QIEInputPulse* pulse, float cut);
 
  private:
   /// Indices of first bin of each subrange

--- a/include/TrigScint/TestBeamClusterProducer.h
+++ b/include/TrigScint/TestBeamClusterProducer.h
@@ -94,7 +94,11 @@ class TestBeamClusterProducer : public framework::Producer {
 
   // fraction of cluster energy deposition associated with beam electron sim
   // hits
+  // -- could convert this to instead be a "cleanb frac"; fraction of cluster energy coming from clean hits 
   float beamE_{0.};
+
+  /// boolean indicating whether we want to apply quality criteria from hit reconstruction
+  bool doCleanHits_{false};
 
   // cluster time (energy weighted based on hit time)
   float time_{0.};

--- a/include/TrigScint/TestBeamHitAnalyzer.h
+++ b/include/TrigScint/TestBeamHitAnalyzer.h
@@ -57,7 +57,10 @@ namespace trigscint {
     int nChannels{16};
     int nTrkMax{100};
 	TH2F* hEvDisp;
+	TH2F* hEvDispPE;
 
+	int fillNb{0};
+	
 	//match nev, nchan above
 	TH1F* hOut[200][16];;
 	TH1F* hPE[16];

--- a/include/TrigScint/TestBeamHitProducer.h
+++ b/include/TrigScint/TestBeamHitProducer.h
@@ -67,6 +67,9 @@ class TestBeamHitProducer : public framework::Producer {
   /// channel pedestals [fC]
   std::vector<double> peds_;
 
+  /// channel MIP response for intercalibration
+  std::vector<double> MIPresponse_;
+
   /// start sample for pulse integration (not including any fiber offsets)
   int startSample_{10};
 
@@ -80,7 +83,7 @@ class TestBeamHitProducer : public framework::Producer {
   int nInstrumentedChannels_{12};
 
 /// boolean indicating whether we want to apply quality criteria in hit reconstruction
-  int doCleanHits_{false};
+  bool doCleanHits_{false};
 
 };
 

--- a/include/TrigScint/TrigScintQIEDigiProducer.h
+++ b/include/TrigScint/TrigScintQIEDigiProducer.h
@@ -127,6 +127,9 @@ class TrigScintQIEDigiProducer : public framework::Producer {
   /// QIE sampling frequency [in MHz]
   float s_freq_;
 
+  /// Zero-suppression: discard any integrated pulses with PE < this number
+  float zeroSuppCut_{1.};
+
   /// SimQIE pointer
   SimQIE* smq_{nullptr};
 };

--- a/python/trigScint.py
+++ b/python/trigScint.py
@@ -77,7 +77,8 @@ class TrigScintQIEDigiProducer(ldmxcfg.Producer) :
         self.elec_noise = 1.5    # Electronic noise (in fC)
         self.sipm_gain = 1.e6    # SiPM Gain
         self.qie_sf = 40.        # QIE sampling frequency in MHz
-
+        self.zeroSupp_in_pe = 1. # min nPE in integrated pulse to keep hit  
+        
         import time
         self.verbose = False
 

--- a/python/trigScint.py
+++ b/python/trigScint.py
@@ -133,7 +133,8 @@ class TestBeamHitProducer(ldmxcfg.Producer) :
         self.startSample=10   # Sample where pulse is expected to start (triggered mode)
         self.pulseWidth=5     # Number of consecutive samples to include in the pulse
         self.pulseWidthLYSO=8 # as above, for LYSO 
-        self.gain = [2.e6]*12      # SiPM Gain  //TODO: vector 
+        self.gain = [2.e6]*12      # SiPM Gain
+        self.MIPresponse = [1.]*12      # channel MIP response correction factor 
         self.pedestals=[
             -4.6, #0.6,
             -2.6, #4.4,
@@ -169,6 +170,7 @@ class TestBeamClusterProducer(ldmxcfg.Producer) :
         self.input_collection="testBeamHitsUp"
         self.input_pass_name="" #take any pass
         self.output_collection="TestBeamClustersUp"
+        self.doCleanHits = False   #whether to apply quality criteria from hit reconstruction
         self.verbosity = 0
 
     def up() :
@@ -282,6 +284,38 @@ class QIEAnalyzer(ldmxcfg.Analyzer) :
 
         self.inputCollection="QIEsamplesUp"
         self.inputPassName=""   #take any pass                                                                                         
+        self.startSample=2      #first time sample included in reformatting 
+        self.gain = [2.e6]*16      # SiPM Gain  //TODO: vector 
+        self.pedestals=[
+            -4.6, #0.6,
+            -2.6, #4.4,
+            -0.6, #-1.25,
+            4.5,  #3.9, 	 # #3
+            1.9,  #10000., # #4: (used to be) dead channel during test beam
+            -2.2, #-2.1,   # #5 
+            0.9,  #2.9,    # #6
+            -1.2, #-2,     # #7
+            4.8,  #-0.4,   # #8
+            -4.4, #-1.1,   # #9: dead channel in TTU teststand setup
+            -0.1, #1.5,    # #10
+            -1.7, #2.0,    # #11
+            3.3,  #3.7,    # #12 -- uninstrumented
+            -0.3, #2.8,    # #13 -- uninstrumented
+            1.3,  #-1.5,   # #14 -- uninstrumented
+            1.3   #1.6     # #15 -- uninstrumented
+        ]
+
+        
+class QualityFlagAnalyzer(ldmxcfg.Analyzer) :
+    """Configuration for linearized QIE analyzer for Trigger Scintillators"""
+    
+    def __init__(self,name) :
+        super().__init__(name,'trigscint::QualityFlagAnalyzer','TrigScint')
+
+        self.inputEventCollection="QIEsamplesUp"
+        self.inputEventPassName=""   #take any pass                                                                                         
+        self.inputHitCollection="testBeamHitsUp"
+        self.inputHitPassName=""   #take any pass                                                                                         
         self.startSample=2      #first time sample included in reformatting 
         self.gain = [2.e6]*16      # SiPM Gain  //TODO: vector 
         self.pedestals=[

--- a/src/TrigScint/EventReadoutProducer.cxx
+++ b/src/TrigScint/EventReadoutProducer.cxx
@@ -21,12 +21,23 @@ void EventReadoutProducer::configure(
   timeShift_ = parameters.getParameter<int>("time_shift");
   fiberToShift_ = parameters.getParameter<int>("fiber_to_shift");
   verbose_ = parameters.getParameter<bool>("verbose");
+
+
+  ldmx_log(debug) << "In configure, got parameters:" <<
+	"\noutput_collection = " << outputCollection_ <<
+	"\ninput_collection = " << inputCollection_ <<
+	"\ninput_pass_name  = " << inputPassName_ <<
+	"\nnumber_pedestal_samples  = " <<  nPedSamples_ <<
+	"\ntime_shift = " <<  timeShift_ <<
+	"\nfiber_to_shift  = " <<  fiberToShift_ <<
+	"\nverbose          = " << verbose_ ;
+  
 }
 
 void EventReadoutProducer::produce(framework::Event &event) {
   // initialize QIE object for linearizing ADCs
   SimQIE qie;
-  
+                                                                                               
   const auto digis{event.getCollection<trigscint::TrigScintQIEDigis>(
       inputCollection_, inputPassName_)};
 
@@ -71,23 +82,50 @@ void EventReadoutProducer::produce(framework::Event &event) {
 	  iS++;
 	}
 	outEvent.setQ(charge); //set in proper order before sorting 
-	outEvent.setQError(chargeErr); //set in proper order before sorting 
+	outEvent.setQError(chargeErr); //set in proper order before sorting
 	earlyPed/=nPedSamples_;
 	outEvent.setEarlyPedestal(earlyPed);
+
+	// oscillation check. for this the pulse charge needs to be in order, so set this up now
+	// the period is 4.
+	// ansatz: an oscillation is a repeated shape. normalize to maxq=1, in every interval of 4 samples
+	// if after normalization the same numbers are repeated, it's an oscillation
+	// edge case: multiple single PE peaks with that repetition. we probably don't need to keep those anyway 
+	if (verbose_)
+	  ldmx_log(debug) << "going into oscillations check ";
+	std::vector <float> chargeCheck = {NULL};
+	float minCharge=10;  //no point in looking at oscillations just around the pedestal. nearest edge is 10.35 fC  //ADC=0 corresponds to -16 fC. 
+	for (int i=3; i<charge.size()-4; i++) {
+	  float maxSamp=minCharge; 
+	  for (int iQ=0; iQ<4; iQ++) { //find the local max in the 4 samples
+		//		ldmx_log(debug) << "got charge " << charge[i+iQ];	
+		if (charge[i+iQ] > maxSamp)
+		  maxSamp=charge[i+iQ];
+	  }
+	  if (verbose_)
+		ldmx_log(debug) << "got max charge " << maxSamp;
+	  for (int iQ=0; iQ<4; iQ++) //store the locally normalized numbers. even if the period is 5 this should work for a while
+		chargeCheck.push_back(charge[i+iQ]/maxSamp);
+	  i+=3; //to increment by 4, do 3 here and 1 in the loop 
+	}
+	
+	
 	//now calculate the pedestal as the average of the middle half of the sorted vector 
 	float ped = 0;
 	std::sort(charge.begin(), charge.end());
-	int quartLength=(int)charge.size()/4;
-	for (int i = quartLength; i < 3*quartLength ; i++) {
+	int pedLength=(int)charge.size()/5; //actually pulse can be up to 12 samples = 2/5*30
+	int pedOffset=2; //but still skip the lowest (and highest) few 
+	//	for (int i = pedLength; i < 3*pedLength ; i++) { //use 2nd and third 5th 
+	for (int i = pedOffset; i < 2*pedLength+pedOffset ; i++) { //use 1st and 2nd 5th 
 	  ped+=charge[i];
 	}
-	ped/=2*quartLength;
+	ped/=2*pedLength;
 	//median: technically only true for odd number of elements but good enough 
 	float medQ=charge[ (int)charge.size()/2 ];
 	float minQ=charge[0];
 	float maxQ=charge[charge.size() -1];
 
-	outEvent.setTotQ(totPosQ-nPos*ped); //store (event) ped subtracted total charge, before dividing by N 
+	outEvent.setTotQ(totPosQ);//-nPos*ped); //store (event) ped subtracted total charge, before dividing by N  --> actually, ped subtraction makes it confusing 
 	//	outEvent.setTotQ(totPosQ-adc.size()*ped); //store (event) ped subtracted total charge, before dividing by N 
 	//	outEvent.setTotQ(avgQ-adc.size()*ped); //store (event) ped subtracted total charge, before dividing by N 
 	avgQ/=adc.size();
@@ -97,28 +135,90 @@ void EventReadoutProducer::produce(framework::Event &event) {
 	outEvent.setMinQ(minQ);
 	outEvent.setMaxQ(maxQ);
 
-
-	//and the noise as the RMSE of that 
+	//and the noise as the RMSE of that, same interval as pedestal 
 	float diffSq = 0;
-    for (int i = quartLength; i < 3*quartLength ; i++) {
-	  //	for (auto& val: charge)	{
+	//    for (int i = pedLength; i < 3*pedLength ; i++) {
+    for (int i = pedOffset; i < 2*pedLength+pedOffset ; i++) {
 	  diffSq+=(charge[i]-ped)*(charge[i]-ped);
 	}
-	diffSq/=2*quartLength; //adc.size(); 
+	diffSq/=2*pedLength; //adc.size(); 
 	outEvent.setNoise( sqrt(diffSq) );
 
+	//oscillation check 
+	uint flagOscillation = 0;
+	//no need to run tedious oscillation check for all-neg channels 
+	if (maxQ > minCharge) {
+	  int maxID=0; 
+	  //find the first occurence of a local max
+	  for (int i=0; i<chargeCheck.size()-4; i++) {
+		if (chargeCheck[i]==1) {  //an actual local max has been normalised by its own value
+		  maxID=i;
+		  //		  ldmx_log(debug) << "storing max index " <<maxID <<" and size of vector is " << chargeCheck.size()-4;
+		  break;
+		}
+	  }
+	  int lastMatchSample=0;
+	  //start from local max
+	  bool doBreak=false;
+	  for (int i=maxID; i<chargeCheck.size()-4; i++) {
+		if (verbose_)
+		ldmx_log(debug) << "Checking how many matching groups of four we can find, starting at index " << i;
+		
+		for (int iQ=0; iQ<4; iQ++) { //check if they are consistently close
+		  if (verbose_)
+			ldmx_log(debug) << "Comparing " << chargeCheck[i+iQ] << " (sample "<< i+iQ << ") to " << chargeCheck[i+4+iQ] << " (sample "<< i+4+iQ << "), ratio is " << chargeCheck[i+iQ]/chargeCheck[i+4+iQ];
+		  //we can be generous in these crietira since we will require an unbroken suite of 8 matches to call it oscillation 
+		  if ( fabs(chargeCheck[i+iQ]/chargeCheck[i+4+iQ]-1) <0.5 || //need this tolerance to be kind of large, most actual peaks won't pass it by far anyway.
+			   (chargeCheck[i+4+iQ]<0.01 && fabs(chargeCheck[i+iQ]/chargeCheck[i+4+iQ]) <5 ) ) // for very small numbers, one ADC difference can be a factor 3 so add some margin 
+			lastMatchSample=i+iQ;
+		  else {
+			if (verbose_)
+			  ldmx_log(debug) << "Oscillation check for channel " << digi.getChanID() << " breaking at time sample " << i+iQ;
+			doBreak=true; //break outer loop 
+			break; //break this loop
+		}
+		}
+		if (doBreak) {
+		  break;
+		}
+		if (verbose_)
+		  ldmx_log(debug) << "Current lastMatchSample " << lastMatchSample;
+		if (lastMatchSample-maxID>=2*4 ) { //we had at least a couple of oscillations (2nd period was fully matched by third)
+		  flagOscillation = 1;  //there is another check possible later too, commented for now
+		  break; //we've seen what we need to see
+		}
+		i+=3;
+	  }
+	} //if positive maxQ 
+  
+	
+	// //use the top and bottom ends of the sorted q as another oscillation catcher: we don't expect that the top values will be high and basically identical unless they are from an oscillation
+	int nHigh=0;
+	int quartLength=(int)charge.size()/4;
+	for (int i = 4*quartLength-2; i >= 3*quartLength ; i--) { //maxQ is already at last index
+	   if (charge[i]/maxQ > 0.66)
+		 nHigh++;
+	}
+	  
+	
+	uint flagSpike = (maxQ/outEvent.getTotQ() > 0.9 ) || (charge[charge.size()-2]/maxQ < 0.25) ; // skip "unnaturally" narrow hits (all charge in one sample or huge drop to second highest)
+	uint flagPlateau = ( ped>15 || nHigh >= 5); //( fabs(ped) > 15 ); //threshold //   //skip events that have strange plateaus   
+	uint flagLongPulse = 0; //easier to deal with in hit reconstruction directly. copy channel flags to hit flags and add this one there
+	uint flagNoise= (outEvent.getNoise() > 3.5 || outEvent.getNoise()==0);  // =0 is typically from funky events but could be too harsh maybe 
+	/* //let this wait for now 
+	//if we have many high counts, a small event pedestal (where they weren't included), and an avgQ ~ maxQ/nHigh, then this is an oscillation
+	if ( (quartLength-nHigh<2 && ped<10) || fabs( maxQ/(avgQ*nHigh)-1 ) <0.1 )
+	  flagOscillation=1;
+*/
 
-	uint flagSpike = (maxQ/outEvent.getTotQ() > 0.8 ); // skip "unnaturally" narrow hits
-	uint flagPlateau = ( fabs(ped) > 15 ); //threshold //   //skip events that have strange plateaus   
-	uint flagLongPulse = 0; //might be easier to deal with in hit reconstruction directly. could copy channel flags to hit flags and add this one there
-	uint flagOscillation = ( fabs(avgQ/ped) > 3./4 );
-	/*
+	
+	/* //this seems to not catch what we want it to
 if ( fabs(chan.getPedestal()) < 15 //threshold //   //skip events that have strange plateaus                                                    
                //              && (chan.getAvgQ()/chan.getPedestal()<0.8)  //skip events that have strange oscillations                                   
                && 1 < nSampAboveThr && nSampAboveThr < 10 ) // skip one-time sample flips and long weird pulses                                           
 	*/
-  uint flag=flagSpike+2*flagPlateau+4*flagLongPulse+8*flagOscillation;
-  ldmx_log(debug) << "Got quality flag "  << flag << " made up of (spike/plateau/long pulse/oscillation) " << flagSpike << "+" << flagPlateau << "+" << flagLongPulse << "+" << flagOscillation ;
+  uint flag=flagSpike+2*flagPlateau+4*flagLongPulse+8*flagOscillation+16*flagNoise;
+  ldmx_log(debug) << "Got quality flag "  << flag << " made up of (spike/plateau/long pulse/oscillation/noise) " << flagSpike << "+" << flagPlateau << "+" << flagLongPulse << "+" << flagOscillation  << "+" << flagNoise ;
   outEvent.setQualityFlag( flag );
 
 	

--- a/src/TrigScint/QualityFlagAnalyzer.cxx
+++ b/src/TrigScint/QualityFlagAnalyzer.cxx
@@ -1,0 +1,201 @@
+/**
+ * @file QualityFlagAnalyzer.cxx
+ * @brief An analyzer drawing the most basic quanities of Trigger Scintillator bars
+ * @author Lene Kristian Bryngemark, Stanford University
+ */
+
+#include "TrigScint/QualityFlagAnalyzer.h"
+
+namespace trigscint {
+
+  QualityFlagAnalyzer::QualityFlagAnalyzer(const std::string& name,
+						   framework::Process& process)
+    : Analyzer(name, process) {}
+  QualityFlagAnalyzer::~QualityFlagAnalyzer() {}
+  
+  void QualityFlagAnalyzer::configure(framework::config::Parameters &parameters){
+
+    inputEventCol_  = parameters.getParameter< std::string >("inputEventCollection");
+    inputEventPassName_  = parameters.getParameter< std::string >("inputEventPassName");
+    inputHitCol_  = parameters.getParameter< std::string >("inputHitCollection");
+    inputHitPassName_  = parameters.getParameter< std::string >("inputHitPassName");
+    peds_  = parameters.getParameter< std::vector<double> >("pedestals");
+    gain_  = parameters.getParameter< std::vector<double> >("gain");
+    startSample_  = parameters.getParameter< int >("startSample");
+
+    std::cout << " [ QualityFlagAnalyzer ] In configure(), got parameters " 
+	      << "\n\t inputEventCollection = " << inputEventCol_
+	      << "\n\t inputEventPassName = " << inputEventPassName_
+	      << "\n\t inputHitCollection = " << inputHitCol_
+	      << "\n\t inputHitPassName = " << inputHitPassName_
+	      << "\n\t startSample = " << startSample_
+	      << "\n\t pedestals[0] = " << peds_[0]
+	      << "\n\t gain[0] = " << gain_[0]
+	      << "\t." << std::endl;
+
+    return;
+  }
+
+  void QualityFlagAnalyzer::analyze(const framework::Event &event) {
+
+    const auto channels{event.getCollection<trigscint::EventReadout >(inputEventCol_, inputEventPassName_)};
+    const auto hits{event.getCollection<trigscint::TestBeamHit >(inputHitCol_, inputHitPassName_)};
+
+	int evNb = event.getEventNumber();
+	//	while (evNb < 0 ) {
+	//  ldmx_log(debug) << "event number = " << evNb << " < 0; incrementing event number ";
+	//  evNb++;
+	//}
+	int nChan = channels.size();
+	ldmx_log(debug) << "in event " << evNb << "; nChannels = " << nChan;
+
+	bool existsIntermediatePE = false;
+	float hitPEs[nChannels] = {0.}; 
+	
+	//ok. get each channel, and find the associated hit, using bar nb. 
+
+	for (auto chan : channels) {
+	  std::vector<float> q = chan.getQ();
+	  std::vector<float> qErr = chan.getQError();
+	  std::vector<int> tdc = chan.getTDC();
+	  int nTimeSamp = q.size();
+	  int bar = chan.getChanID();
+
+	  int flag = chan.getQualityFlag();
+	  
+	   //check if this is messing up flag 
+	  for (auto hit : hits) { //we will be ok even if there is no match
+		if (hit.getBarID() == bar ) { //
+		  flag = hit.getQualityFlag();
+		  hitPEs[bar]= hit.getPE();
+		  if ( flag==0 && bar < 12 && 15 < hit.getPE() && hit.getPE() < 40)
+			existsIntermediatePE=true;
+		}
+	  }
+
+	  ldmx_log(debug) << "Got event flag " << flag;
+
+	  //if flag = 0, fill for clean versions of the usual event displays
+	  if ( flag==0 && evNb < nEv && bar < nChannels ) { //stick within the predefined histogram array
+		for (int iT = 0; iT < q.size() ; iT++) {
+		  ldmx_log(debug) << "in event " << evNb << "; channel " << bar << ", got charge[" << iT << "] = " << q.at(iT);
+		  hOut[evNb][bar]->SetBinContent(iT+startSample_, q.at(iT));
+		  hOut[evNb][bar]->SetBinError(iT+startSample_, fabs(qErr.at(iT)) );
+		}//if within the number of events to plot individually
+	  }//over time samples
+
+	  // now select on flags
+	  //special case: flag = 0 (this will happen to all eventually, so catch it now
+	  if (flag == 0 && nEvDrawn[nFlags-1] < nEv ) { //then draw if we haven't collected enough                      
+		int fillNb=nEvDrawn[nFlags-1];
+		for (int iT = 0; iT < q.size() ; iT++) { //fill this plot with all q
+			hOutFlag[nFlags-1][fillNb][bar]->SetBinContent(iT+startSample_, q.at(iT));
+            hOutFlag[nFlags-1][fillNb][bar]->SetBinError(iT+startSample_, fabs(qErr.at(iT)) );
+          }
+		  //keep track of actual event number 
+		  hOutFlag[nFlags-1][fillNb][bar]->GetYaxis()->SetTitle(Form("Q, flag 0, chan %i, ev %i [fC]", bar,evNb));
+		  nEvDrawn[nFlags-1]++;  //update filled event counter for this flag (0)
+	  }//if nothing was flagged 
+	  else { //hit was flagged somehow
+		for (int iF=0;iF<nFlags-1;iF++) { //do all but the last
+		  int fillNb=nEvDrawn[iF];
+		  ldmx_log(debug) << "Checking flag " << flags[iF];
+		  //we're starting from the high numbers and iteratively subtracting
+		  if (flag >= flags[iF] ) {
+			ldmx_log(debug) << "Checking flag " << flags[iF];
+			if (fillNb < nEv ) { //then 1. this flag must be raised 2. draw if we haven't collected enough
+			  for (int iT = 0; iT < q.size() ; iT++) { //fill this plot with all q
+				hOutFlag[iF][fillNb][bar]->SetBinContent(iT+startSample_, q.at(iT));
+				hOutFlag[iF][fillNb][bar]->SetBinError(iT+startSample_, fabs(qErr.at(iT)) );
+			  }//over time samples 
+			  hOutFlag[iF][fillNb][bar]->GetYaxis()->SetTitle(Form("Q, flag %i, chan %i, ev %i [fC]", flags[iF],bar,evNb));
+			nEvDrawn[iF]++;  //update filled event counter for this flag
+			}
+			flag-=flags[iF]; //subtract that flag from sum
+		  }//if this flag 
+		}//over flags
+	  }//if any non-zero flag
+	}//over channels	
+		
+	
+	// select 15 < PE < 40 events 	
+	if ( existsIntermediatePE && peFillNb < nEv ) { //then 1. this flag must be raised 2. draw if we haven't collected enough
+	  ldmx_log(debug) << "Got at least one intermediate PE channel";
+	  for (auto chan : channels) {
+		std::vector<float> q = chan.getQ();
+		std::vector<float> qErr = chan.getQError();
+		std::vector<int> tdc = chan.getTDC();
+		int nTimeSamp = q.size();
+		int bar = chan.getChanID();
+		for (int iT = 0; iT < q.size() ; iT++) { //fill this plot with all q
+		  hOutPE[peFillNb][bar]->SetBinContent(iT+startSample_, q.at(iT));
+		  hOutPE[peFillNb][bar]->SetBinError(iT+startSample_, fabs(qErr.at(iT)) );
+		}//over time samples 
+		hOutPE[peFillNb][bar]->GetYaxis()->SetTitle(Form("Q, chan %i, ev %i, PE %.2f", bar,evNb,hitPEs[bar]));
+	  }//over channels	
+	  peFillNb++;  //update filled event counter for this flag
+	} //if fill 
+	
+	
+    return;
+  }
+
+  void QualityFlagAnalyzer::onFileOpen() {
+    std::cout << "\n\n File is opening! My analyzer should do something -- like print this \n\n" << std::endl;
+
+    return;
+  }
+
+  void QualityFlagAnalyzer::onFileClose() {
+
+    return;
+  }
+  
+  void QualityFlagAnalyzer::onProcessStart() {
+    std::cout << "\n\n Process starts! My analyzer should do something -- like print this \n\n" << std::endl;
+    getHistoDirectory();
+	
+	int nTimeSamp=40;
+	int PEmax=100;
+	int nPEbins=5*PEmax;
+	float Qmax=PEmax/(6250./4.e6);
+	float Qmin=-10;
+	int nQbins=(Qmax-Qmin)/4;
+
+	ldmx_log(debug) << "Setting up histograms... " ;
+
+	for (int iB = 0; iB<nChannels; iB++) {
+	  hPE[iB]=new TH1F(Form("hPE_chan%i", iB), Form(";PE, chan%i", iB),nPEbins,0,PEmax);
+	}
+
+	for (int iE = 0; iE<nEv; iE++) {
+	  for (int iB = 0; iB<nChannels; iB++) { 
+		hOut[iE][iB] = new TH1F(Form("hCharge_chan%i_ev%i", iB, iE), Form(";time sample; Q, channel %i, event %i [fC]", iB, iE), nTimeSamp,-0.5,nTimeSamp-0.5);
+		hOutPE[iE][iB] = new TH1F(Form("hCharge_PEcut_chan%i_nb%i", iB, iE), Form(";time sample; Q, channel %i, event %i [fC]", iB, iE), nTimeSamp,-0.5,nTimeSamp-0.5);
+		for (int iF=0; iF<nFlags; iF++) { 
+		  hOutFlag[iF][iE][iB] = new TH1F(Form("hCharge_flag%i_chan%i_nb%i", flags[iF],iB, iE), Form(";time sample; Q, flag %i, chan %i, ev %i [fC]", iF, iB, iE), nTimeSamp,-0.5,nTimeSamp-0.5); //less confusing to name them upon actual use 
+		  //hOutFlag[iF][iE][iB] = new TH1F("hCharge_flag",  "", nTimeSamp,-0.5,nTimeSamp-0.5);
+		}
+	  }
+	}
+
+
+	hTDCfireChanvsEvent = new TH2F("hTDCfireChanvsEvent", ";channel with TDC < 63;event number", nChannels,-0.5,nChannels-0.5, nEv, 0, nEv);
+	
+	evNb = 0;
+	peFillNb=0;
+	ldmx_log(debug) << "done setting up histograms" ;
+
+    return;
+  }
+  
+
+  void QualityFlagAnalyzer::onProcessEnd() {
+
+    return;
+  }
+
+
+}
+
+DECLARE_ANALYZER_NS(trigscint, QualityFlagAnalyzer)

--- a/src/TrigScint/SimQIE.cxx
+++ b/src/TrigScint/SimQIE.cxx
@@ -129,16 +129,20 @@ std::vector<int> SimQIE::CapID(QIEInputPulse* pp) {
   return OP;
 }
 
-bool SimQIE::PulseCut(QIEInputPulse* pulse) {
+  bool SimQIE::PulseCut(QIEInputPulse* pulse, float cut) {
   if (pulse->GetNPulses() == 0) return false;
 
-  // Only keep the pulse if it produces 1 PE
-  // in atleast one of the time samples
-  float thr_in_pes = 1.0;
+  //  float thr_in_pes = 1.0; instead make configurable 
 
+  // Only keep the pulse if it produces 1 PE (or whatever the cutoff is set to)
+  //integrate over entire pulse so we catch also single-PE pulses 
+  float integral=0;
   for (int i = 0; i < maxts_; i++) {
-    if (pulse->Integrate(i * tau_, i * tau_ + tau_) >= thr_in_pes) return true;
+	//    if (pulse->Integrate(i * tau_, i * tau_ + tau_) >= thr_in_pes) return true;
+	integral+= pulse->Integrate(i * tau_, i * tau_ + tau_);
   }
+  if ( integral >= cut) return true;
+  
   return false;
 }
 }  // namespace trigscint

--- a/src/TrigScint/TestBeamClusterProducer.cxx
+++ b/src/TrigScint/TestBeamClusterProducer.cxx
@@ -14,6 +14,7 @@ void TestBeamClusterProducer::configure(framework::config::Parameters &ps) {
   input_collection_ = ps.getParameter<std::string>("input_collection");
   passName_ = ps.getParameter<std::string>("input_pass_name");
   output_collection_ = ps.getParameter<std::string>("output_collection");
+  doCleanHits_  = ps.getParameter< bool >("doCleanHits");
   verbose_ = ps.getParameter<int>("verbosity");
 
   timeTolerance_ = ps.getParameter<double>("time_tolerance");
@@ -25,6 +26,7 @@ void TestBeamClusterProducer::configure(framework::config::Parameters &ps) {
                    << "\nMax cluster width: " << maxWidth_
                    << "\nExpected pad hit time: " << padTime_
                    << "\nMax hit time delay: " << timeTolerance_
+				   << "\n\t doCleanHits = " << doCleanHits_
                    << "\nInput collection:     " << input_collection_
                    << "\nInput pass name:     " << passName_
                    << "\nOutput collection:    " << output_collection_
@@ -112,6 +114,12 @@ void TestBeamClusterProducer::produce(framework::Event &event) {
     // map the index of the digi to the channel index
 	ldmx_log(debug) << "Digi has PE count " << digi.getPE() 
 					<< " and energy " << digi.getEnergy();
+
+	if (doCleanHits_ && digi.getQualityFlag() ) {
+	  ldmx_log(debug) << "Skipping hit with non-zero quality flag  " << digi.getQualityFlag();
+	  continue;
+	}
+	
     if (digi.getPE() >
         minThr_) {  // cut on a min threshold (for a non-seeding hit to be added
                     // to seeded clusters) already here

--- a/src/TrigScint/TrigScintQIEDigiProducer.cxx
+++ b/src/TrigScint/TrigScintQIEDigiProducer.cxx
@@ -57,7 +57,8 @@ void TrigScintQIEDigiProducer::configure(
   ldmx_log(debug) << "sipm_gain =" << sipm_gain_;
   ldmx_log(debug) << "qie_sf =" << s_freq_;
   ldmx_log(debug) << "zeroSupp_in_pe =" << zeroSuppCut_;
-
+  ldmx_log(debug) << "pe_per_mip =" << pePerMip_;
+  ldmx_log(debug) << "mev_per_mip =" << mevPerMip_;
 }
 
 void TrigScintQIEDigiProducer::produce(framework::Event& event) {

--- a/src/TrigScint/TrigScintQIEDigiProducer.cxx
+++ b/src/TrigScint/TrigScintQIEDigiProducer.cxx
@@ -97,7 +97,7 @@ void TrigScintQIEDigiProducer::produce(framework::Event& event) {
   for (const auto& simHit : simHits) {
     ldmx::TrigScintID id(simHit.getID());
 
-    ldmx_log(info) << "Processing sim hit with bar ID: " << id.bar();
+    ldmx_log(debug) << "Processing sim hit with bar ID: " << id.bar();
 
     // Simulating the noise corresponding to uncertainity in
     // detecting scintillating photons.

--- a/src/TrigScint/TrigScintQIEDigiProducer.cxx
+++ b/src/TrigScint/TrigScintQIEDigiProducer.cxx
@@ -36,7 +36,8 @@ void TrigScintQIEDigiProducer::configure(
   elec_noise_ = parameters.getParameter<double>("elec_noise");
   sipm_gain_ = parameters.getParameter<double>("sipm_gain");
   s_freq_ = parameters.getParameter<double>("qie_sf");
-
+  zeroSuppCut_ = parameters.getParameter<double>("zeroSupp_in_pe");
+  
   if (input_pulse_shape_ == "Expo") {
     pulse_params_.clear();
     pulse_params_.push_back(parameters.getParameter<double>("expo_k"));
@@ -54,7 +55,9 @@ void TrigScintQIEDigiProducer::configure(
   ldmx_log(debug) << "pedestal =" << pedestal_;
   ldmx_log(debug) << "elec_noise =" << elec_noise_;
   ldmx_log(debug) << "sipm_gain =" << sipm_gain_;
-  ldmx_log(debug) << "s_freq =" << s_freq_;
+  ldmx_log(debug) << "qie_sf =" << s_freq_;
+  ldmx_log(debug) << "zeroSupp_in_pe =" << zeroSuppCut_;
+
 }
 
 void TrigScintQIEDigiProducer::produce(framework::Event& event) {
@@ -131,7 +134,7 @@ void TrigScintQIEDigiProducer::produce(framework::Event& event) {
     }
 
     // Storing the "good" digis
-    if (smq_->PulseCut(ex[bar_id])) {
+    if (smq_->PulseCut(ex[bar_id], zeroSuppCut_)) {
       trigscint::TrigScintQIEDigis QIEInfo;
 
       QIEInfo.setChanID(bar_id);

--- a/util/drawQFlags.C
+++ b/util/drawQFlags.C
@@ -1,0 +1,118 @@
+#include <TH1.h>
+#include <TF1.h>
+#include <TH2.h>
+#include <TLine.h>
+#include <TLatex.h>
+#include <TTree.h>
+#include <TCanvas.h>
+#include <TGaxis.h>
+#include <TFile.h>
+#include <TGraphErrors.h>
+#include <TSystem.h>
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+
+void drawQFlags(string inFile, int flag, int maxEvents = 200, int deadChannel =8, int nChannels=16)
+{
+  // plotting macro for histograms of channel readout with a given quality flag set
+
+   int nSiPMs=12; //some channels not connected to SiPMs
+
+   gErrorIgnoreLevel = kWarning; //suppress file writing output 
+   //these are derived as the mean of gaussian fits to total Q in the event. they an vary some but these are ok on average 
+   std::vector <float> pedestals={2.96771, -0.781398, -1.21252, 3.85539, 2.70707, -2.12383, 2.84691, -1.97643, -0.610725, -0.9, 2.3167, 2.02866, 3.3, -0.3, 1.3, 1.3};
+
+   TString outDir(inFile);
+   outDir.ReplaceAll("data/", "");
+   outDir.ReplaceAll("unpacked_", "");
+   outDir.ReplaceAll("reformat_", "");
+   outDir.ReplaceAll("reco", "");
+   outDir.ReplaceAll("_linearize", "");
+   outDir.ReplaceAll("linearize", "");
+   outDir.ReplaceAll("hists", "");
+   outDir.ReplaceAll("_plots", "");
+   outDir.ReplaceAll("plots", "");
+   outDir.ReplaceAll(".root", "");
+   outDir.ReplaceAll("__", "_");
+
+   outDir.Prepend("plots/");
+   std::cout << "Using output subdir " << outDir <<  std::endl;
+
+   if ( gSystem->mkdir(outDir.Data(), true) ) {
+	 std::cout<<"Couldn't create directory " << outDir.Data() << std::endl;
+   }
+
+   TCanvas * c1 = new TCanvas("c1", "canvas", 600, 500);
+   
+   TFile * fIn = TFile::Open( inFile.c_str(), "READ");
+
+   if (!fIn)
+	 std::cout << "Couldn't open " << inFile << std::endl;
+   
+   fIn->cd("plotMaker"); 
+   //  fIn->ls();
+  
+  TLatex * latex = new TLatex();
+  latex->SetNDC();
+  latex->SetTextSize(0.04);
+
+  TF1 * fPed = new TF1("fPed", "[0]", -5, 50);
+  fPed->SetLineStyle(2);
+  fPed->SetLineColor(kBlue+2);
+
+  float leftMarg, rightMarg, topMarg, bottomMarg;
+  float leftMarg2, rightMarg2, topMarg2, bottomMarg2;
+  bool hasDrawnCanvas=false;
+  for (int iE = 1; iE < maxEvents; iE++) { //event counts start from event number 1
+	vector <TH1F*> vH(nChannels);
+	float maxQ=0.;
+	float minQ=0.;
+	float ped=0;
+	
+	for (int iC = 0 ; iC < nChannels ; iC++) {
+	  //for (int iC = 0 ; iC < nSiPMs ; iC++) { //consider this to skip uninstrumented channels, but for now, they are a good reference point 
+	  bool drawTDC = false;
+	  ped = 0;
+	  TH1F * h =(TH1F*)gDirectory->Get(Form("hCharge_flag%i_chan%i_nb%i", flag,iC,iE));
+	  if (!h ) {
+		std::cout << "Couldn't find histogram " << Form("hCharge_flag%i_chan%i_nb%i", flag,iC,iE) << std::endl;
+		continue;
+	  }
+	  if (h->GetEntries() == 0 )
+		continue;
+	  if (h->GetMaximum() > maxQ )
+		maxQ = h->GetMaximum();
+	  if (h->GetMinimum() < minQ )
+		minQ = h->GetMinimum();
+	  h->DrawCopy("he"); 
+
+	  //here: calculate the actual event pedestal 
+	  vector<float> vals;
+	  for (int iB = 1; iB <= h->GetNbinsX(); iB++ )
+		vals.push_back( h->GetBinContent(iB) );
+	  std::sort(vals.begin(), vals.end());
+	  int quartLength=(int)vals.size()/4;
+	  for (int i = quartLength; i < 3*quartLength ; i++) {
+		ped+=vals[i];
+	  }
+	  ped/=2*quartLength;
+	  fPed->SetParameter(0, ped);
+	  fPed->DrawCopy("same");
+
+	  TString titleStr(h->GetTitle());
+	  titleStr.ReplaceAll(Form("Q, flag %i, ",flag), "");
+	  titleStr.ReplaceAll(" [fC]", "");
+	  latex->DrawLatex(0.67, 0.75, titleStr);
+
+	  c1->SaveAs(Form("%s/hCharge_flag%i_ch%i_nb%i.pdf", outDir.Data(),flag,iC,iE));
+
+	}
+  }
+
+  
+  //Done.
+}

--- a/util/extractResponse.C
+++ b/util/extractResponse.C
@@ -1,0 +1,183 @@
+#include <TH1.h>
+#include <TF1.h>
+#include <TH2.h>
+#include <TTree.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TFitResult.h>
+#include <TGraphErrors.h>
+
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+
+// Quadratic background function
+Double_t background(Double_t *x, Double_t *par) {
+  return par[0] + par[1]*x[0] + par[2]*x[0]*x[0];
+}
+
+// Lorentzian Peak function
+Double_t lorentzianPeak(Double_t *x, Double_t *par) {
+  return (0.5*par[0]*par[1]/TMath::Pi()) / TMath::Max(1.e-10,
+													  (x[0]-par[2])*(x[0]-par[2])+ .25*par[1]*par[1]);
+}
+
+
+//some function with a broader low side
+Double_t asymPeak(Double_t *x, Double_t *par) {
+  Double_t expo=TMath::Exp((x[0]-par[1])/par[0]);
+  par[2]=sqrt(fabs(par[1]));
+  return 1/par[0]*expo*TMath::Exp( -expo );
+  //f(x)=1βe−x−μβe−e−x−μβ
+}
+
+// Gaussian Peak function                                                                                                                                    
+Double_t gaussianPeak(Double_t *x, Double_t *par) {
+  return par[0]*TMath::Exp(  -0.5*((x[0]-par[1])/par[2])*((x[0]-par[1])/par[2])  );
+}
+
+
+// Sum of background and peak function
+Double_t fitFunction(Double_t *x, Double_t *par) {
+  //  return background(x,par) + lorentzianPeak(x,&par[3]);
+  return gaussianPeak(x,par) + background(x,&par[3]);
+}
+void extractResponse(string inFile, int deadChannel=-1, string passName = "TBreco", int nSamples = 30, int verbosity=2, bool isSim=false, bool doClean=false)
+{
+  // macro extracting the per-channel MIP response based on calibrated hits
+  //
+
+  // we need hits, that are cleaned and calibrated
+  // the average PE response, fit it --> this is what we calibrate to
+  // then for each channel, fit and get mean
+  // store the per-channel scale factor so we can apply it in the MIP regime 
+  // done
+  
+
+  bool verbosePrint = (verbosity == 0 ); //adhere to ldmx printout lavel numbering
+  
+  TFile * fIn = TFile::Open( inFile.c_str(), "READ");
+  TTree * tree = (TTree*)fIn->Get("LDMX_Events");
+  fIn->ls();
+  int exampleEvNb = 1;
+
+  string digiName="testBeamHitsUp";
+  int nChannels = 12;
+  
+  vector<string> vars = {"pe"}; // this variable is totQ/nSamp
+  vector <int> maxVals = {200};  // don't need to go high, focus on the single-few PE peaks 
+  vector <int> minVals = {20};  // should cover most negative pedestals 
+  vector <float> binFactor = {0.15}; // histogram binning: bins per integer 
+
+  TCanvas * c1 = new TCanvas("c1", "plot canvas", 600, 500);
+
+  vector<string> cuts;
+  vector<TH1F*> v_hOut;
+
+  string cleanStr="";
+  if (doClean)
+	cleanStr=Form("(%s_%s.flag_ == 0 || %s_%s.flag_ == 4) &&", digiName.c_str(),passName.c_str(), digiName.c_str(),passName.c_str());
+  
+  for (int iC = 0 ; iC < nChannels ; iC++)
+	cuts.push_back( Form("%s %s_%s.barID_ == %i", cleanStr.c_str(), digiName.c_str(),passName.c_str(), iC));
+
+  c1->SetRightMargin( 1.5*c1->GetRightMargin());
+
+  for (unsigned int iV = 0; iV < vars.size(); iV++) {
+	for (unsigned int iC = 0; iC < cuts.size(); iC++) {
+	  string cut =cuts[iC];
+	  //set up binning
+	  string bins = Form("%i, %i, %i", (int)(binFactor[iV]*(maxVals[iV]-minVals[iV])), minVals[iV], maxVals[iV]);
+	  if (iC == 0)
+		std::cout << bins << std::endl;
+	  //draw from the tree
+	  string bin = Form("%i", iC);
+	  string nSamp = Form("%i", nSamples);
+	  std::cout<<"At channel " << bin << std::endl;
+	  std::cout<<"Using cut " << cut << std::endl;
+	  tree->Draw( (digiName+"_"+passName+"."+vars[iV]+"_ >> h"+bin+"("+bins+")").c_str(), cut.c_str() );
+	  //get them each and keep for later
+	  TH1F *hOut = (TH1F*)gDirectory->Get(Form("h%i", iC)); 
+	  if (!hOut || hOut->IsZombie()) {
+		std::cout << "No histogram for channel " << iC << ", skipping" << std::endl;
+		continue;
+	  }
+	  //set up axes 	  
+	  string title = ";"+vars[iV]+" "+cut+";entries";
+	  hOut->SetTitle( title.c_str() );
+	  hOut->GetYaxis()->SetRangeUser(0.001, 1.5*hOut->GetMaximum()) ;
+	  //draw 
+	  hOut->Draw();
+	  hOut->SetName(Form("h%s_chanID%i", vars[iV].c_str(), iC));
+	  v_hOut.push_back( (TH1F*)hOut->Clone() );
+	}//over cuts
+  }//over variables 
+
+
+  //make a histogram with all channels
+
+  TH1F * hAll = (TH1F*)v_hOut[0]->Clone("hPE_all");
+  for (unsigned int iC = 1; iC < nChannels; iC++) {
+	if (iC == deadChannel)
+	  continue;
+	hAll->Add(v_hOut[iC]);
+  }
+
+  TFitResultPtr fPtr = hAll->Fit("landau", "S");
+  float avgResponse = fPtr->Parameter(1);
+  std::cout << "Got MPV for all channels combined: " << avgResponse << std::endl;
+	
+  // ok so now we have all the histograms. we just need to fit them...
+
+  float fitRangeWidth=125.; // take this window to either side of mean to catch peak 
+  TGraphErrors* gMPVs = new TGraphErrors(nChannels);
+  for (unsigned int iH = 0;  iH < v_hOut.size(); iH++) {
+	if (iH == deadChannel)
+	  continue;
+	//do the actual peak fitting 
+	std::cout<< "----> Fitting response for channel " << iH << std::endl;
+	TFitResultPtr fResult = v_hOut.at(iH)->Fit("landau", "QS");
+	std::cout << "For channel " << iH << ", got MPV \t" << fResult->Parameter(1) << std::endl;
+	gMPVs->SetPoint( iH, iH, fResult->Parameter(1));
+	gMPVs->SetPointError( iH, 0, fResult->ParError(1));
+  }
+
+  
+  //store this to a root file for later plotting
+  TString outFile = inFile;
+  outFile=outFile.ReplaceAll(".root", "_response.root");
+  std::cout << "using outfile name" "" << outFile << std::endl;
+
+  TFile * fOut = TFile::Open( outFile.Data(), "RECREATE");
+  fOut->cd();
+  fOut->ls();
+  std::cout << "Got " << v_hOut.size() << " histograms" << std::endl;
+  int nChanToWrite = deadChannel > -1 ? nChannels - 1 : nChannels; //adjust for if we have a dead channel in this run
+   for (unsigned int iH = 0;  iH < v_hOut.size(); iH++) {
+	v_hOut[iH]->Write();
+  }
+  if (deadChannel > -1 ) { //if there in fact is one (TODO: allow for list?)
+	gMPVs->RemovePoint(deadChannel);
+  }
+  gMPVs->SetTitle(";channel ID;MIP peak fit MPV");
+  gMPVs->Write("gMIPResponseVsChanID");
+  fOut->Close();
+  fIn->Close();
+  
+  //write responses to a .txt file for easy extraction of calibration in the hit reconstruction step 
+  TString responseFile = inFile;
+  responseFile=responseFile.ReplaceAll(".root", "_response.txt");
+  ofstream fResponse;// responseFile.Data());
+  fResponse.open( responseFile.Data());
+  for (int iP = 0; iP < gMPVs->GetN(); iP++) {
+	double x, MPV;
+    gMPVs->GetPoint(iP, x, MPV);
+	fResponse << x << "," << avgResponse/MPV << "\n";
+  }
+  fResponse.close();
+    //Done.
+}
+


### PR DESCRIPTION
This PR includes making hit reconstruction integrate over the full number of time samples, and a few minor bug fixes such as correct pedestal subtraction and zero suppression.

Also it reduces the QIEDigi verbosity which was an old issue. 

Closes #41 and closes #21 .
