### PR TITLE
Add in testbeam fixes: allow long pulses, gain fit fixes, no cap on events

### DIFF
--- a/exampleConfigs/runClusterAna.py
+++ b/exampleConfigs/runClusterAna.py
@@ -1,0 +1,39 @@
+import sys
+from LDMX.Framework import ldmxcfg
+from LDMX.SimCore import generators
+from LDMX.SimCore import simulator
+
+thisPassName="plot"
+p = ldmxcfg.Process(thisPassName)
+
+
+if len(sys.argv) > 1 :
+    inFile=sys.argv[1]
+else :
+    print("specify an input file")
+    exit
+
+p.inputFiles=[  inFile ]
+
+from LDMX.TrigScint.trigScint import TestBeamClusterAnalyzer
+
+clAna3hit = TestBeamClusterAnalyzer("3-hitClusters")
+clAna3hit.inputCollection="TestBeamClustersPad1ThreeHits"
+
+clAna2hit = TestBeamClusterAnalyzer("2-hitClusters")
+clAna2hit.inputCollection="TestBeamClustersPad1"
+
+
+
+outname=p.inputFiles[0].replace(".root", "_plots.root")
+#p.outputFiles = [ outname ]
+p.histogramFile = outname 
+
+p.sequence=[clAna2hit,
+            #clAna3hit
+            #      tsEv,
+            #      tsAna
+                  ]
+
+
+p.termLogLevel = 2

--- a/exampleConfigs/runQIEDecode.py
+++ b/exampleConfigs/runQIEDecode.py
@@ -10,6 +10,8 @@ nEv=400000
 nChan=16
 #mapFile="channelMapFrontBack_"+str(nChan)+"channels.txt" #../TrigScint/data/channelMapFrontBack.txt")
 
+#p.maxEvents = nEv
+
 p.inputFiles=[sys.argv[1]]
 p.outputFiles = [sys.argv[2]]
 inputPass=sys.argv[3]
@@ -41,7 +43,6 @@ p.sequence = [
     dec
     ]
 
-p.maxEvents = nEv
 p.termLogLevel = 1
 p.logFileName = logName
 p.fileLogLevel = logVerbosity

--- a/exampleConfigs/runRawUnpacker.py
+++ b/exampleConfigs/runRawUnpacker.py
@@ -13,7 +13,7 @@ else :
     nTimeSamples=24 #default
 
 if len(sys.argv) > 4 :
-    nEv=int(sys.argv[4])
+    nEv=sys.argv[4] #int(sys.argv[4])
 else :
     nEv=4e6 #default         
 
@@ -29,7 +29,7 @@ p.sequence = [
     rawio.SingleSubsystemUnpacker(raw_file = RAWfileName, output_name = "QIEstreamUp", detector_name="ldmx-hcal-prototype-v1.0", num_bytes_per_event = nWords)
         ]
 
-p.maxEvents = nEv # apparently this HAS TO be set! single subsystem unpacker will abort all events when it runs out of data
+p.maxEvents = int(nEv) # apparently this HAS TO be set! single subsystem unpacker will abort all events when it runs out of data
 
 p.termLogLevel = 0 #1 
 p.logFileName = logName

--- a/exampleConfigs/runTSLinearizer.py
+++ b/exampleConfigs/runTSLinearizer.py
@@ -6,6 +6,8 @@ import sys
 inputPassName="unpack"
 nEv=400000
 
+#p.maxEvents = nEv
+
 if len(sys.argv) > 2 :
     timeOffset=int(sys.argv[2])
 else :
@@ -38,7 +40,6 @@ outname=outname.replace("_reco.root", ".root")
 outname=outname.replace(".root", "_linearize.root")
 p.outputFiles = [ outname ]
 
-p.maxEvents = nEv
 
 p.logFileName=p.outputFiles[0].replace(".root",".log")
 p.termLogLevel = 2

--- a/exampleConfigs/runTSsimAndReco.py
+++ b/exampleConfigs/runTSsimAndReco.py
@@ -1,0 +1,193 @@
+import sys
+from LDMX.Framework import ldmxcfg
+from LDMX.SimCore import generators
+from LDMX.SimCore import simulator
+
+thisPassName="sim"
+p = ldmxcfg.Process(thisPassName)
+
+from LDMX.Hcal import HcalGeometry
+#from LDMX.Ecal import EcalGeometry
+
+nEvents = 4000
+killChan8 = True # toggle to kill all signal from channel 8 (dead in testbeam)
+nElectrons=2
+beamEnergy=4.  #in GeV
+
+nChannels=12
+gainList=[2e6]*nChannels
+pedList=[6.]*nChannels
+
+if killChan8 :
+    gainList[8]=gainList[8]*gainList[8]  #to make the hit PEs very small
+    killString="killChan8_"
+
+
+gunZpos=800 #3000  #mm -- define as positive here, for file naming; set sign below
+detV=2.0        #detector geometry version number 
+beamXsmear=7.5 #mm    7.5mm for reasonable efficiency, larger than TS module to get more empty (no MIP)  events. set to 150mm for large noise 
+beamYsmear=20  #mm    20 mm      -- " --, set to 200 for large noise 
+noisePerEvent=0.08  #average number of PEs from SiPM noise per event (gets scaled by nTimeSamples to be constant) -- 0.1 per event is taken from run183 
+startSample=15
+
+if len(sys.argv) > 1 :
+    nTimeSamples=int(sys.argv[1])
+else :
+    nTimeSamples=30 #config default is 5 
+if len(sys.argv) > 2 :
+    elecNoise=float(sys.argv[2])
+else :
+    elecNoise=1.5 #config default is 1.5
+if len(sys.argv) > 3 :
+    kExpo=float(sys.argv[3])
+else :
+    kExpo=0.1   #config default is 0.1
+    
+p.run = 1
+p.maxEvents = nEvents
+p.outputFiles = ['testbeamSim_'+str(nElectrons)+'e_zNeg'+str(gunZpos)+'mm_beamSpot'+str(beamXsmear)+'x'+str(beamYsmear)+'mm_'+str(nTimeSamples)+'tSamp_eNoise'+str(elecNoise)+'_tauInv'+str(kExpo)+'_detV'+str(detV)+'_'+killString+str(p.maxEvents)+'ev.root']
+print("Producing output file: "+p.outputFiles[0])
+
+gunZpos   =-float(gunZpos)  #get sign right, and make floats, to use as parameters
+beamXsmear=float(beamXsmear)
+beamYsmear=float(beamYsmear)
+
+#gunZpos=-1404. #mm
+#gunZpos=-1504. #mm
+#gunZpos=-1204. #mm
+
+#------ set up beam simulation -------
+
+
+mpgGen = generators.multi( "mgpGen" ) # this is the line that actually creates the generator
+mpgGen.vertex = [ 0., 0., gunZpos ] # mm
+mpgGen.nParticles = nElectrons
+mpgGen.pdgID = 11
+mpgGen.enablePoisson = False #True
+mpgGen.momentum = [ 0., 0., beamEnergy ]
+
+gun = generators.gun('particle_gun')
+gun.particle = 'e-'
+gun.direction = [0., 0., 1.]
+gun.position = [0., 0., gunZpos]
+gun.energy = beamEnergy   #gev
+
+simulation = simulator.simulator('test_TS')
+simulation.generators=[mpgGen] #gun]
+simulation.setDetector('ldmx-hcal-prototype-v'+str(detV))
+#simulation.setDetector('ldmx-hcal-prototype-v1.0')
+simulation.beamSpotSmear = [beamXsmear, beamYsmear, 0] #mm, at start position
+simulation.description = "Inclusive "+str(beamEnergy)+" GeV electron events, "+str(nElectrons)+"e"
+
+
+#### the digi and tb hit step not fully implemented !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#------ set up digitization -------
+
+from LDMX.TrigScint.trigScint import TrigScintQIEDigiProducer
+
+tsDigis = TrigScintQIEDigiProducer.pad1() #up() #
+tsDigis.input_collection= "TriggerPadUpSimHits"
+tsDigis.number_of_strips = 12
+tsDigis.mean_noise=float(noisePerEvent/nTimeSamples)
+
+tsDigis.maxts = nTimeSamples
+tsDigis.elec_noise = elecNoise
+tsDigis.expo_k = kExpo
+tsDigis.sipm_gain = 2.e6
+tsDigis.zeroSupp_in_pe=0.5
+tsDigis.toff_overall = 25.*startSample
+tsDigis.pe_per_mip = 110. #from fit to 2-hit clusters in data run 183, April4 2310, all plastic
+
+
+#------ set up event readout linearization -------
+
+from LDMX.TrigScint.trigScint import EventReadoutProducer
+
+tsEv=EventReadoutProducer("eventLinearizer")
+tsEv.input_pass_name=thisPassName
+tsEv.input_collection=tsDigis.output_collection #"trigScintQIEDigisPad1"
+tsEv.time_shift=0 #timeOffset
+tsEv.verbose = True 
+
+#------ set up hit reconstruction -------
+
+from LDMX.TrigScint.trigScint import TestBeamHitProducer
+
+tbHits  =TestBeamHitProducer("tbHits")
+tbHits.inputPassName=thisPassName
+#if inputPassName=="sim" : #different conventions in sim and data
+#    tbHits.inputCollection="trigScintQIEDigisPad1"
+#else :
+tbHits.inputCollection="QIEsamplesPad1"
+tbHits.pedestals=pedList
+tbHits.gain=gainList 
+tbHits.startSample=startSample
+tbHits.pulseWidth=12 #5 
+tbHits.pulseWidthLYSO=12
+tbHits.doCleanHits=True
+tbHits.nInstrumentedChannels=nChannels
+
+
+#------ set up clustering -------
+
+from LDMX.TrigScint.trigScint import TestBeamClusterProducer
+
+tbClusters  =TestBeamClusterProducer("tbClusters")
+tbClusters.input_pass_name=thisPassName
+tbClusters.input_collection=tbHits.outputCollection #"trigScintQIEDigisPad1" #
+tbClusters.pad_time=100.
+tbClusters.time_tolerance=999.
+tbClusters.verbosity=0
+tbClusters.clustering_threshold = 50.  #to add in neighboring
+
+tbClusters3  =TestBeamClusterProducer("tbClusters3")
+tbClusters3.input_pass_name=thisPassName
+tbClusters3.input_collection=tbHits.outputCollection 
+tbClusters3.output_collection=tbClusters.output_collection+"ThreeHits"
+tbClusters3.max_cluster_width=3
+tbClusters3.pad_time=100.
+tbClusters3.time_tolerance=999.
+tbClusters3.verbosity=0
+tbClusters3.clustering_threshold = 50.  #to add in neighboring
+
+
+#### ---- analyzers ------
+
+from LDMX.TrigScint.trigScint import QIEAnalyzer
+
+tsAna=QIEAnalyzer("plotMaker")
+tsAna.inputPassName=thisPassName
+tsAna.startSample=0
+tsAna.pedestals=pedList
+tsAna.gain=gainList
+
+
+from LDMX.TrigScint.trigScint import TestBeamClusterAnalyzer
+
+clAna2hit = TestBeamClusterAnalyzer("2-hitClusters")
+clAna2hit.inputCollection=tbClusters.output_collection
+
+clAna3hit = TestBeamClusterAnalyzer("3-hitClusters")
+clAna3hit.inputCollection=tbClusters3.output_collection
+
+
+
+outname=p.outputFiles[0].replace(".root", "_plots.root")
+#p.outputFiles = [ outname ]
+p.histogramFile = outname 
+
+p.sequence=[simulation,
+            tsDigis,
+            tsEv,
+            tbHits,
+            tbClusters3,
+            tbClusters,
+            #clAna2hit,
+            #clAna3hit
+            #      tsEv,
+            #      tsAna
+                  ]
+
+
+p.termLogLevel = 2

--- a/exampleConfigs/runTestBeamClustering.py
+++ b/exampleConfigs/runTestBeamClustering.py
@@ -6,6 +6,7 @@ import sys
 
 inputPassName="hits"
 nEv=400000
+#p.maxEvents = nEv
 
 if len(sys.argv) > 2 :
     timeSample=int(sys.argv[2])
@@ -29,7 +30,6 @@ p.sequence = [
 #generate on the fly
 p.inputFiles = [sys.argv[1]]
 p.outputFiles = [ sys.argv[1].replace(".root", "_clusters.root") ]
-p.maxEvents = nEv
 
 p.termLogLevel = 2
 p.logFileName = p.outputFiles[0].replace(".root", ".log") 

--- a/exampleConfigs/runTestBeamHitReco.py
+++ b/exampleConfigs/runTestBeamHitReco.py
@@ -7,6 +7,7 @@ import sys
 
 inputPassName="conv"
 nEv=400000
+#p.maxEvents = nEv
 
 if len(sys.argv) > 2 :
     timeSample=int(sys.argv[2])
@@ -36,7 +37,7 @@ if exists(gainFileName) :
     with open(gainFileName) as f:
         for line in f.readlines() :
             line=line.split(',')  #values are comma separated, one channel per line: channelNB, gain
-            gainList[ int(line[0].strip()) ] = float(line[1].strip())
+            gainList[ int(line[0].strip()) ] = float(line[1].strip()) #don't assume ordered
 
 print("Using this list of gains:")
 print(gainList)
@@ -45,12 +46,12 @@ pedList=[
             -4.6,  #0.6,
             -2.6, #4.4,
             -0.6, #-1.25,
-            4.4,  #3.9, 	 # #3
+            4.4,  #3.9,    # #3
             1.9,  #10000., # #4: (used to be) dead channel during test beam
             -2.3, #-2.1,   # #5 
             1.0,  #2.9,    # #6
             -1.2, #-2,     # #7
-            4.9,  #-0.4,   # #8
+            4.9,  #-0.4,   # #8  dead channel in spring 2022 testbeam at CERN, most of the runs 
             -4.4, #-1.1,   # #9: dead channel in TTU teststand setup
             -0.1, #1.5,    # #10
             -1.7, #2.0,    # #11
@@ -79,12 +80,12 @@ print(pedList)
 
 tbHitsUp  =TestBeamHitProducer("tbHits")
 tbHitsUp.input_pass_name=inputPassName
-tbHitsUp.input_collection="QIEsamplesUp"
+tbHitsUp.input_collection="QIEsamplesPad1" #"QIEsamplesUp"
 tbHitsUp.pedestals=pedList
 tbHitsUp.gain=gainList 
 tbHitsUp.startSample=timeSample
 tbHitsUp.pulseWidth=7 #5 
-tbHitsUp.pulseWidthLYSO=9 #7 
+tbHitsUp.pulseWidthLYSO=7 #9 #7 for plastic, 9 for LYSO 
 tbHitsUp.doCleanHits=True
 tbHitsUp.nInstrumentedChannels=12
 p.sequence = [
@@ -95,6 +96,5 @@ p.sequence = [
 #generate on the fly
 p.inputFiles = [sys.argv[1]]
 p.outputFiles = [ sys.argv[1].replace(".root", "_hits.root") ]
-p.maxEvents = nEv
 
 p.termLogLevel = 2

--- a/include/TrigScint/TestBeamClusterAnalyzer.h
+++ b/include/TrigScint/TestBeamClusterAnalyzer.h
@@ -45,9 +45,9 @@ class TestBeamClusterAnalyzer : public framework::Analyzer {
   // plotting stuff
   int nChannels{16};
   // match nchan above
-  TH1F* hN3N2;
-  TH1F* hN3N1;
-  TH1F* hN2N1;
+  TH2F* hN3N2;
+  TH2F* hN3N1;
+  TH2F* hN2N1;
   TH1F* hNClusters;
   TH1F* hNHits;
   TH1F* hNhitsInClusters;

--- a/include/TrigScint/TestBeamClusterAnalyzer.h
+++ b/include/TrigScint/TestBeamClusterAnalyzer.h
@@ -1,0 +1,62 @@
+/**
+ * @file TestBeamClusterAnalyzer.h
+ * @brief
+ * @author
+ */
+
+#ifndef TRIGSCINT_TESTBEAMCLUSTERANALYZER_H
+#define TRIGSCINT_TESTBEAMCLUSTERANALYZER_H
+
+// LDMX Framework
+#include "Framework/Configure/Parameters.h"
+#include "Framework/EventProcessor.h"  //Needed to declare processor
+#include "TH1.h"
+#include "TH2.h"
+#include "TrigScint/Event/TrigScintCluster.h"
+
+namespace trigscint {
+
+/**
+ * @class TestBeamClusterAnalyzer
+ * @brief
+ */
+class TestBeamClusterAnalyzer : public framework::Analyzer {
+ public:
+  TestBeamClusterAnalyzer(
+      const std::string& name,
+      framework::Process& process);  // : framework::Analyzer(name, process) {}
+  virtual ~TestBeamClusterAnalyzer() = default;
+  void configure(framework::config::Parameters& parameters) override;
+
+  void analyze(const framework::Event& event) override;
+
+  void onProcessStart() override;
+
+  void onProcessEnd() override;
+
+ private:
+
+  // configurable parameters
+  std::string inputCol_;       // input coll. containing 2-hit clusters (standard)
+  std::string inputPassName_{""};
+  //  std::string wideInputCol_;   // input coll. containing 3-hit clusters 
+  //  std::string wideInputPassName_{inputPassName};  // default to same pass 
+
+  // plotting stuff
+  int nChannels{16};
+  // match nchan above
+  TH1F* hN3N2;
+  TH1F* hN3N1;
+  TH1F* hN2N1;
+  TH1F* hNClusters;
+  TH1F* hNHits;
+  TH1F* hNhitsInClusters;
+  TH1F* hPEinHits[16];
+  TH1F* hPEinClusters[16];
+  TH1F* hDeltaCentroids;
+  TH2F* hDeltaVsSeed;
+
+};
+}  // namespace trigscint
+
+#endif /* TRIGSCINT_TESTBEAMCLUSTERANALYZER_H */

--- a/src/TrigScint/EventReadoutProducer.cxx
+++ b/src/TrigScint/EventReadoutProducer.cxx
@@ -200,8 +200,10 @@ void EventReadoutProducer::produce(framework::Event &event) {
 		 nHigh++;
 	}
 	  
-	
-	uint flagSpike = (maxQ/outEvent.getTotQ() > 0.9 ) || (charge[charge.size()-2]/maxQ < 0.25) ; // skip "unnaturally" narrow hits (all charge in one sample or huge drop to second highest)
+	/* used to be: >0.9, > 0.25. But this really killed MC pulses which
+	   all end up in 0.90-0.94, and somewhere >0.05 (at least >0.15)
+	*/
+	uint flagSpike = (maxQ/outEvent.getTotQ() > 0.95 ) || (charge[charge.size()-2]/maxQ < 0.05) ; // skip "unnaturally" narrow hits (all charge in one sample or huge drop to second highest)
 	uint flagPlateau = ( ped>15 || nHigh >= 5); //( fabs(ped) > 15 ); //threshold //   //skip events that have strange plateaus   
 	uint flagLongPulse = 0; //easier to deal with in hit reconstruction directly. copy channel flags to hit flags and add this one there
 	uint flagNoise= (outEvent.getNoise() > 3.5 || outEvent.getNoise()==0);  // =0 is typically from funky events but could be too harsh maybe 

--- a/src/TrigScint/TestBeamClusterAnalyzer.cxx
+++ b/src/TrigScint/TestBeamClusterAnalyzer.cxx
@@ -1,0 +1,130 @@
+/**
+ * @file TestBeamClusterAnalyzer.cxx
+ * @brief An analyzer drawing the most basic quanities of Trigger Scintillator
+ * bars
+ * @author Lene Kristian Bryngemark, Stanford University
+ */
+
+#include "TrigScint/TestBeamClusterAnalyzer.h"
+
+namespace trigscint {
+
+TestBeamClusterAnalyzer::TestBeamClusterAnalyzer(const std::string& name,
+                                         framework::Process& process)
+    : Analyzer(name, process) {}
+
+void TestBeamClusterAnalyzer::configure(framework::config::Parameters& parameters) {
+  inputCol_ = parameters.getParameter<std::string>("inputCollection");
+  inputPassName_ = parameters.getParameter<std::string>("inputPassName");
+  //  wideInputCol_ = parameters.getParameter<std::string>("3hitInputCollection");
+  //wideInputPassName_ = parameters.getParameter<std::string>("3hitInputPassName");
+
+  std::cout << " [ TestBeamClusterAnalyzer ] In configure(), got parameters "
+            << "\n\t inputCollection = " << inputCol_
+            << "\n\t inputPassName = " << inputPassName_
+			<< std::endl;
+    //        << "\n\t 3hitInputCollection = " << wideInputCol_
+    //        << "\n\t 3hitInputPassName = " << wideInputPassName_
+
+  return;
+}
+
+void TestBeamClusterAnalyzer::analyze(const framework::Event& event) {
+  if (!event.exists(inputCol_, inputPassName_) ) {
+	ldmx_log(info) << "No cluster collection " << inputCol_ << "_" << inputPassName_ << " found. Skipping analysis of event";
+    return;
+  }
+  
+  const auto clusters{
+      event.getCollection<ldmx::TrigScintCluster>(inputCol_, inputPassName_)};
+
+  int n1hit=0;
+  int n2hit=0;
+  int n3hit=0;
+
+  int nClusters=clusters.size();
+  
+  for (auto cluster : clusters) {
+    int seed = cluster.getSeed();
+    int nHits = cluster.getNHits();
+	if ( nHits == 3 )
+	  n3hit++;
+	else if ( nHits == 2 )
+	  n2hit++;
+	else if ( nHits == 1 )
+	  n1hit++;
+	
+    float PE = cluster.getPE();
+
+	hPEinClusters[seed]->Fill(PE);
+
+	/* // this requires different implementation. use getHitIDs and use the indices in there
+	   // in a loop over hits in the event to extract the PEs 
+	   // -- later. 
+	for (auto hits : cluster.getConstituents() )
+	  hPEinHits[seed]->Fill(PE);
+	*/
+  }  // over clusters
+  if (nClusters > 1) {
+	hDeltaCentroids->Fill( fabs(clusters[0].getCentroid()-clusters[1].getCentroid()) );
+	hDeltaVsSeed->Fill(clusters[0].getSeed(), fabs(clusters[0].getCentroid()-clusters[1].getCentroid()) );
+  }
+
+  
+  if (n2hit)
+	hN3N2->Fill((float)n3hit/n2hit);
+  if (n1hit) {
+	hN3N1->Fill((float)n3hit/n1hit);
+	hN2N1->Fill((float)n2hit/n1hit);
+  }
+  hNClusters->Fill(nClusters);
+  //todo: get hit collection to fill Nhits later?
+  hNHits->Fill(3*n3hit+2*n2hit+n1hit);
+	
+
+  return;
+}
+
+void TestBeamClusterAnalyzer::onProcessStart() {
+  std::cout << "\n\n Process starts! My analyzer should do something -- like "
+               "print this \n\n"
+            << std::endl;
+
+  getHistoDirectory();
+
+  int PEmax = 600;
+  int nPEbins =0.5*PEmax;
+  // float Qmax = PEmax / (6250. / 4.e6);
+  // float Qmin = -10;
+  // int nQbins = (Qmax - Qmin) / 4;
+
+  for (int iB = 0; iB < nChannels; iB++) {
+    hPEinHits[iB] = new TH1F(Form("hPE_chan%i", iB), Form(";PE, chan%i", iB), nPEbins,
+                       0, PEmax);
+    hPEinClusters[iB] = new TH1F(Form("hPEinClusters_chan%i", iB),
+                                 Form(";PE, chan%i", iB), nPEbins, 0, PEmax);
+  }
+
+  hDeltaVsSeed = new TH2F(
+        "hDeltaVsSeed", ";BarID_{seed};#Delta_{centroid}", nChannels + 1,
+        - 0.5,nChannels-0.5, 5*nChannels,0,nChannels);
+
+  hDeltaCentroids = new TH1F("hDeltaCentroids",";#Delta_{centroid}",  5*nChannels,
+							- 0.5, nChannels-0.5);
+
+  hNHits = new TH1F("hNHits", "Number of hits in the event; N_{hits}; Events", 10, 0, 10);
+  hNClusters = new TH1F("hNClusters", "Number of clusters in the event; N_{clusters}; Events", 10, 0, 10);
+
+
+  hN3N2 = new TH1F("hN3N2", "Ratio of 3-hit to 2-hit clusters; N_{3-hit}/N_{2-hit}; Events", 10, 0, 4);
+  hN3N1 = new TH1F("hN3N1", "Ratio of 3-hit to 1-hit clusters; N_{3-hit}/N_{1-hit}; Events", 10, 0, 4);
+  hN2N1 = new TH1F("hN2N1", "Ratio of 2-hit to 1-hit clusters; N_{2-hit}/N_{1-hit}; Events", 10, 0, 4);
+  
+  return;
+}
+
+void TestBeamClusterAnalyzer::onProcessEnd() { return; }
+
+}  // namespace trigscint
+
+DECLARE_ANALYZER_NS(trigscint, TestBeamClusterAnalyzer)

--- a/src/TrigScint/TestBeamClusterProducer.cxx
+++ b/src/TrigScint/TestBeamClusterProducer.cxx
@@ -115,7 +115,7 @@ void TestBeamClusterProducer::produce(framework::Event &event) {
 	ldmx_log(debug) << "Digi has PE count " << digi.getPE() 
 					<< " and energy " << digi.getEnergy();
 
-	if (doCleanHits_ && digi.getQualityFlag() ) {
+	if (doCleanHits_ && digi.getQualityFlag() && digi.getQualityFlag() != 4 ) { //allow for long pulse hits 
 	  ldmx_log(debug) << "Skipping hit with non-zero quality flag  " << digi.getQualityFlag();
 	  continue;
 	}

--- a/src/TrigScint/TestBeamHitProducer.cxx
+++ b/src/TrigScint/TestBeamHitProducer.cxx
@@ -139,7 +139,7 @@ namespace trigscint {
 		//		int isLongPulse=(nSampAboveThr < 2 || nSampAboveThr > width + 2);
 		int isLongPulse=( nSampAboveThr > width );  //the short ones we'll have to single out otherwise (like spike flag or low Q) or live with
 		flag += 4*isLongPulse;
-		  if ( maxQ > 2e3 && nSampAboveThr < 3 && flag%2==0 ) //this was not flagged as a spike but is eerily narrow and with highQ; flag it as a spike. 
+		  if ( maxQ > 2e5 && nSampAboveThr < 3 && flag%2==0 ) //this was not flagged as a spike but is eerily narrow and with high Q; flag it as a spike. 
 			flag +=1;
 		if ( flag == 0 )
 			isClean=1;


### PR DESCRIPTION
This updates a few example configs, tweaks the testbeam clustering, and allows for removing more than one dead channel in the gain fits.